### PR TITLE
SPICEPCR-1399 Update orbnum label generation with NPB for date format

### DIFF
--- a/src/pds/naif_pds4_bundler/classes/product.py
+++ b/src/pds/naif_pds4_bundler/classes/product.py
@@ -15,6 +15,7 @@ from datetime import date
 import numpy as np
 import spiceypy
 
+from ..utils.time import parse_date
 from ..utils import add_carriage_return
 from ..utils import add_crs_to_file
 from ..utils import check_eol
@@ -2867,7 +2868,7 @@ class OrbnumFileProduct(Product):
             # time-tags of the orbnum file.
             #
             start_time = self._sample_record.split()[1]
-            start = datetime.datetime.strptime(start_time, "%Y-%b-%d-%H:%M:%S")
+            start = parse_date(start_time)
             start_time = start.strftime("%Y-%m-%dT%H:%M:%SZ")
 
             #
@@ -2896,7 +2897,7 @@ class OrbnumFileProduct(Product):
                 stop_time = last_line.split()[3]
 
             try:
-                stop = datetime.datetime.strptime(stop_time, "%Y-%b-%d-%H:%M:%S")
+                stop = parse_date(stop_time)
                 stop_time = stop.strftime("%Y-%m-%dT%H:%M:%SZ")
             except BaseException:
                 #

--- a/src/pds/naif_pds4_bundler/utils/time.py
+++ b/src/pds/naif_pds4_bundler/utils/time.py
@@ -424,3 +424,21 @@ def get_years(start_time, stop_time):
         year += 1
 
     return years
+
+
+def parse_date(date_str):
+    """Parses a date string using the following formats:
+        * %Y-%b-%d-%H:%M:%S
+        * %Y-%m-%dT%H:%M:%S
+
+    :param date_str: Stop time to determine list of years
+    :type date_str: str
+    :return: date corresponding to the input str
+    :rtype: datetime
+    """
+    try:
+        date = datetime.datetime.strptime(date_str, "%Y-%b-%d-%H:%M:%S")
+    except ValueError:
+        date = datetime.datetime.strptime(date_str, "%Y-%m-%dT%H:%M:%S")
+
+    return date

--- a/tests/naif_pds4_bundler/config/bc.xml
+++ b/tests/naif_pds4_bundler/config/bc.xml
@@ -715,5 +715,19 @@
             <author>ESA SPICE Service</author>
             <observer>MMO</observer>
         </orbnum>
+        <orbnum>
+            <pattern>bc_mpo_flp_[0-9]{8}_[0-9]{8}_v[0-9]{2}.orb</pattern>
+            <event_detection_frame>
+                <spice_name>IAU_MERCURY</spice_name>
+                <description>Mercury body-fixed frame</description>
+            </event_detection_frame>
+            <header_start_line>1</header_start_line >
+            <pck>
+                <kernel_name>pck0011.tpc</kernel_name>
+                <description>December 27, 2022</description>
+            </pck>
+            <author>ESA SPICE Service</author>
+            <observer>MPO</observer>
+        </orbnum>
     </orbit_number_file>
 </naif-pds4-bundler_configuration>

--- a/tests/naif_pds4_bundler/test_unittests.py
+++ b/tests/naif_pds4_bundler/test_unittests.py
@@ -397,6 +397,8 @@ class TestUnitTests(TestCase):
     def test_spk_coverage(self):
         time.test_spk_coverage(self)
 
+    def test_parse_date(self):
+        time.test_parse_dates(self)
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/naif_pds4_bundler/unittests/test_time.py
+++ b/tests/naif_pds4_bundler/unittests/test_time.py
@@ -2,6 +2,7 @@
 import spiceypy
 from pds.naif_pds4_bundler.utils import dsk_coverage
 from pds.naif_pds4_bundler.utils import spk_coverage
+from pds.naif_pds4_bundler.utils.time import parse_date
 
 
 def test_dsk_coverage(self):
@@ -30,4 +31,17 @@ def test_spk_coverage(self):
     self.assertEqual(
         (start_time_cal, stop_time_cal),
         ("2021-02-18T21:52:40.482Z", "2021-05-21T15:47:07.765Z"),
+    )
+
+
+def test_parse_dates(self):
+    """Test parse_dates function."""
+    
+    isoc_str = "2021-02-18T21:52:40"
+    date_str  = "2021-FEB-18-21:52:40"
+
+    isoc_date = parse_date(isoc_str)
+    date = parse_date(date_str)
+    self.assertEqual(
+        isoc_date, date
     )


### PR DESCRIPTION
## 🗒️ Summary
The proposed changes affect the generation of orbnum labels:
* The software shall accept EVENT UTC dates in two formats, in the _coverage_ method of **OrbnumFileProduct** class:
    * '%Y %b %d %H:%M:%S'  (2026 MAR 14 16:47:12)
    * '%Y-%m-%dT%H:%M:%S' (2026-03-20T06:21:38)
* Missing pattern in Bepicolombo configuration (bc.xml)

## ⚙️ Test Data

* Unit test on low level new date parsing function
* Tested label generation on two BC orbit num with different date format.
[bc_mpo_test_data.zip](https://github.com/user-attachments/files/15514472/bc_mpo_test_data.zip)


