### PR TITLE
SPICEPCR-1725 BEPI/JUICE Metakernel template fixed + BEPI BERM IK

### DIFF
--- a/tests/naif_pds4_bundler/config/bc.xml
+++ b/tests/naif_pds4_bundler/config/bc.xml
@@ -195,6 +195,13 @@
             <description>SPICE IK file providing optics, detector, and field-of-view (FOV) parameters for the MPO BepiColombo Laser Altimeter (BELA), created by the ESA SPICE Service (ESS).
             </description>
         </kernel>
+        <kernel pattern="bc_mpo_berm_v[0-9][0-9].ti">
+            <observers>
+                <observer>MPO</observer>
+            </observers>
+            <description>SPICE IK file providing references to mounting alignment, operating modes, and timing as well as internal and FOV geometry for the BepiColombo Radiation Monitor (BERM), created by the ESA SPICE Service (ESS).
+            </description>
+        </kernel>
         <kernel pattern="bc_mtm_mcam_v[0-9][0-9].ti">
             <observers>
                 <observer>MTM</observer>
@@ -636,6 +643,7 @@
                 <pattern>estrack_v[0-9]{2}.tf</pattern>
                 <!-- IK -->
                 <pattern>bc_mpo_bela_v[0-9]{2}.ti</pattern>
+                <pattern>bc_mpo_berm_v[0-9]{2}.ti</pattern>
                 <pattern>bc_mpo_mertis_v[0-9]{2}.ti</pattern>
                 <pattern>bc_mpo_mgns_v[0-9]{2}.ti</pattern>
                 <pattern>bc_mpo_mixs_v[0-9]{2}.ti</pattern>

--- a/tests/naif_pds4_bundler/data/spiceds_bc.html
+++ b/tests/naif_pds4_bundler/data/spiceds_bc.html
@@ -16,7 +16,7 @@
 +-----------------------------------------------------------------------------+
 The BepiColombo Mission Archived SPICE Kernel Data Set
 
-   Last update: 2024-11-06T17:30:00
+   Last update: 2025-09-30T17:30:00
 
 <a name="Introduction"></a>
 Introduction

--- a/tests/naif_pds4_bundler/data/spiceds_bc.html
+++ b/tests/naif_pds4_bundler/data/spiceds_bc.html
@@ -568,6 +568,7 @@ IK Files
                           ssas       for SSAS
                           aux        for Auxiliary
                           bela       for BELA
+                          berm       for BERM
                           mertis     for MERTIS
                           mgns       for MGNS
                           mixs       for MIXS

--- a/tests/naif_pds4_bundler/templates/bc/template_metakernel.tm
+++ b/tests/naif_pds4_bundler/templates/bc/template_metakernel.tm
@@ -1,18 +1,18 @@
 KPL/MK
 
-Meta-kernel for $MISSION_NAME Archived Kernels
+Meta-kernel for $PDS4_MISSION_NAME Archived Kernels
 ==========================================================================
 
-   This meta-kernel lists the $MISSION_NAME Archived SPICE kernels
+   This meta-kernel lists the $PDS4_MISSION_NAME Archived SPICE kernels
    providing information for the full mission. All of the kernels listed
-   below are archived in the PSA $MISSION_NAME SPICE kernel archive.
+   below are archived in the PSA $PDS4_MISSION_NAME SPICE kernel archive.
 
    This set of files and the order in which they are listed were picked to
    provide the best available data and the most complete coverage for the
    specified year based on the information about the kernels available at
    the time this meta-kernel was made. For detailed information about the
    kernels listed below refer to the internal comments included in the
-   kernels and the documentation accompanying the $MISSION_NAME
+   kernels and the documentation accompanying the $PDS4_MISSION_NAME
    SPICE kernel archive.
 
 
@@ -31,7 +31,7 @@ Implementation Notes
 
    It is recommended that users make a local copy of this file and
    modify the value of the PATH_VALUES keyword to point to the actual
-   location of the $MISSION_NAME SPICE data set's ``data'' directory
+   location of the $PDS4_MISSION_NAME SPICE data set's ``data'' directory
    on their system. Replacing ``/'' with ``\'' and converting line
    terminators to the format native to the user's system may also be
    required if this meta-kernel is to be used on a non-UNIX workstation.

--- a/tests/naif_pds4_bundler/templates/juice/template_metakernel.tm
+++ b/tests/naif_pds4_bundler/templates/juice/template_metakernel.tm
@@ -1,18 +1,18 @@
 KPL/MK
 
-Meta-kernel for $MISSION_NAME Archived Kernels
+Meta-kernel for $PDS4_MISSION_NAME Archived Kernels
 ==========================================================================
 
-   This meta-kernel lists the $MISSION_NAME Archived SPICE kernels
+   This meta-kernel lists the $PDS4_MISSION_NAME Archived SPICE kernels
    providing information for the full mission. All of the kernels listed
-   below are archived in the PSA $MISSION_NAME SPICE kernel archive.
+   below are archived in the PSA $PDS4_MISSION_NAME SPICE kernel archive.
 
    This set of files and the order in which they are listed were picked to
    provide the best available data and the most complete coverage for the
    specified year based on the information about the kernels available at
    the time this meta-kernel was made. For detailed information about the
    kernels listed below refer to the internal comments included in the
-   kernels and the documentation accompanying the $MISSION_NAME
+   kernels and the documentation accompanying the $PDS4_MISSION_NAME
    SPICE kernel archive.
 
 
@@ -31,7 +31,7 @@ Implementation Notes
 
    It is recommended that users make a local copy of this file and
    modify the value of the PATH_VALUES keyword to point to the actual
-   location of the $MISSION_NAME SPICE data set's ``data'' directory
+   location of the $PDS4_MISSION_NAME SPICE data set's ``data'' directory
    on their system. Replacing ``/'' with ``\'' and converting line
    terminators to the format native to the user's system may also be
    required if this meta-kernel is to be used on a non-UNIX workstation.

--- a/tests/naif_pds4_bundler/templates/juice/template_product_html_document.xml
+++ b/tests/naif_pds4_bundler/templates/juice/template_product_html_document.xml
@@ -6,7 +6,7 @@
   <Identification_Area>
     <logical_identifier>$PRODUCT_LID</logical_identifier>
     <version_id>$PRODUCT_VID</version_id>
-    <title>$MISSION_NAME SPICE Archive Description</title>
+    <title>$PDS4_MISSION_NAME SPICE Archive Description</title>
     <information_model_version>$INFORMATION_MODEL_VERSION</information_model_version>
     <product_class>Product_Document</product_class>
     <Citation_Information>
@@ -14,7 +14,7 @@
       <keyword>Observation Geometry</keyword>
       <description>
                 This document provides a comprehensive description of
-                the $MISSION_NAME SPICE kernel archive
+                the $PDS4_MISSION_NAME SPICE kernel archive
                 containing observation geometry and other ancillary
                 data in the form of SPICE System kernel files for the
                 $PDS4_OBSERVER_NAME
@@ -31,7 +31,7 @@
       <processing_level>Derived</processing_level>
     </Primary_Result_Summary>
     <Investigation_Area>
-      <name>$MISSION_NAME</name>
+      <name>$PDS4_MISSION_NAME</name>
       <type>Mission</type>
       <Internal_Reference>
         <lid_reference>$PDS4_MISSION_LID</lid_reference>
@@ -43,12 +43,12 @@ $OBSERVERS
     </Observing_System>
   </Context_Area>
   <Document>
-    <document_name>$MISSION_NAME SPICE Archive Description</document_name>
+    <document_name>$PDS4_MISSION_NAME SPICE Archive Description</document_name>
     <publication_date>$PRODUCT_CREATION_DATE</publication_date>
     <document_editions>1</document_editions>
     <description>
             This document provides a comprehensive description of
-            the $MISSION_NAME SPICE kernel archive
+            the $PDS4_MISSION_NAME SPICE kernel archive
             containing observation geometry and other ancillary
             data in the form of SPICE System kernel files for the
             $PDS4_OBSERVER_NAME
@@ -58,12 +58,12 @@ $OBSERVERS
             SPICE software and documentation.
         </description>
     <Document_Edition>
-      <edition_name>$MISSION_NAME SPICE Archive Description</edition_name>
+      <edition_name>$PDS4_MISSION_NAME SPICE Archive Description</edition_name>
       <language>English</language>
       <files>1</files>
       <description>
                 This document provides a comprehensive description of
-                the $MISSION_NAME SPICE kernel archive
+                the $PDS4_MISSION_NAME SPICE kernel archive
                 containing observation geometry and other ancillary
                 data in the form of SPICE System kernel files for the
                 $PDS4_OBSERVER_NAME


### PR DESCRIPTION
## 🗒️ Summary
* BEPICOLOMBO/JUICE metakernel templates fixed (using PDS4_MISSION_NAME)
* BEPICOLOMBO spiceds updated including the BERM IK type
* BEPICOLOMBO configuration bc.xml updated including the BERM IK type

## ⚙️ Test Report
```
.NPB - Functional Tests - TestFunctional
.NPB - Regression Tests - TestRegression
.NPB - Unit Tests - TestUnitTests

----------------------------------------------------------------------
Ran 141 tests in 88.350s

OK
```


